### PR TITLE
Add READY, GUILD_CREATE logging displaying "boot" time

### DIFF
--- a/src/draw_bot/handlers/ready.cr
+++ b/src/draw_bot/handlers/ready.cr
@@ -1,0 +1,22 @@
+module DrawBot
+  # Cache of loaded guild IDs
+  READY_STATE = ReadyState.new
+
+  # READY event handler that counts how many guilds we should
+  # expect from GUILD_CREATE streaming
+  client.on_ready(READY_STATE) do |ctx|
+    Discord::LOGGER.info "Expecting #{READY_STATE.expected_guilds.size} guilds.."
+  end
+
+  # GUILD_CREATE handler that displays logging as the guilds stream in,
+  # (on DEBUG level) as well as elapsed time once the bot is done loading.
+  client.on_guild_create(READY_STATE) do |ctx|
+    if Discord::LOGGER.debug?
+      Discord::LOGGER.debug "Received #{READY_STATE.loaded_guilds.size} / #{READY_STATE.expected_guilds.size} guilds (#{ctx.payload.id} #{ctx.payload.name})"
+    end
+
+    if READY_STATE.ready?
+      Discord::LOGGER.info "Loading complete! #{READY_STATE.loaded_guilds.size} guilds, Elapsed time: #{READY_STATE.elapsed_time}"
+    end
+  end
+end

--- a/src/draw_bot/middleware/ready_state.cr
+++ b/src/draw_bot/middleware/ready_state.cr
@@ -1,0 +1,35 @@
+module DrawBot
+  class ReadyState < Discord::Middleware
+    # Array of expected guild IDs from READY
+    getter expected_guilds = Set(UInt64).new
+
+    # Set of guild IDs we've received GUILD_CREATE for
+    getter loaded_guilds = Set(UInt64).new
+
+    # Time at which guild streaming started
+    getter start_time : Time? = nil
+
+    # Whether all guilds have been observed
+    def ready?
+      expected_guilds == loaded_guilds
+    end
+
+    # Amount of time streaming took
+    def elapsed_time
+      @start_time.try { |value| Time.now - value }
+    end
+
+    def call(context : Discord::Context(Discord::Gateway::ReadyPayload), done)
+      @start_time = Time.now
+      context.payload.guilds.each do |guild|
+        @expected_guilds.add guild.id
+      end
+      done.call
+    end
+
+    def call(context : Discord::Context(Discord::Gateway::GuildCreatePayload), done)
+      @loaded_guilds.add context.payload.id
+      done.call
+    end
+  end
+end


### PR DESCRIPTION
Sample output:
```
➜  drawbot_crystal git:(crystal) bin/bot
I, [2018-04-05 03:59:42 -04:00 #8231]  INFO -- discordcr: Received READY, v: 6
I, [2018-04-05 03:59:42 -04:00 #8231]  INFO -- discordcr: Expecting 578 guilds..
I, [2018-04-05 03:59:43 -04:00 #8231]  INFO -- discordcr: Loading complete! 578 guilds, Elapsed time: 00:00:01.034634000
```