### PR TITLE
CannedResponse: Support underscores in source names

### DIFF
--- a/spec/canned_response_spec.cr
+++ b/spec/canned_response_spec.cr
@@ -26,6 +26,11 @@ module DrawBot
         instance = CannedResponse.new({"foo" => ["bar"]}, "$author")
         instance.produce_response(nil, "baz").should eq "baz"
       end
+
+      it "supports underscores in source names" do
+        instance = CannedResponse.new({"foo_bar" => ["baz"]}, "$foo_bar")
+        instance.produce_response(nil, "baz").should eq "baz"
+      end
     end
   end
 end

--- a/src/draw_bot/middleware/canned_response.cr
+++ b/src/draw_bot/middleware/canned_response.cr
@@ -68,7 +68,7 @@ module DrawBot
     def validate_template
       @sources.each do |key, data|
         uses = 0
-        @template.scan(/\$\w+/) do |word|
+        @template.scan(/\$[a-zA-Z_]+/) do |word|
           uses += 1 if word[0] == "$#{key}"
         end
 
@@ -87,8 +87,9 @@ module DrawBot
           case reader.current_char
           when '$'
             start = reader.pos + 1
-            while reader.has_next? && reader.next_char.letter?
-              # Nothing to do
+            while reader.has_next?
+              char = reader.next_char
+              break unless char.letter? || char == '_'
             end
             key = @template[start..reader.pos - 1]
             case key


### PR DESCRIPTION
I realized during #24 that this wasn't supported, and we definitely want this for "namespaced" data files like `fight_method` and `fight_extreme`.