### PR TITLE
Lint empty data sources in CannedResponse

### DIFF
--- a/data/fortune
+++ b/data/fortune
@@ -32,5 +32,3 @@ No.
 Drawbot says no
 Drawbot says why? Ask later.
 I guess?
-
-

--- a/spec/canned_response_spec.cr
+++ b/spec/canned_response_spec.cr
@@ -8,6 +8,12 @@ module DrawBot
       end
     end
 
+    it "raises when data contains empty lines" do
+      expect_raises(CannedResponseError, "Data source \"foo\" contains empty lines") do
+        CannedResponse.new({"foo" => [""]}, "$foo")
+      end
+    end
+
     describe "#produce_response" do
       it "builds a string with random data into a template" do
         instance = CannedResponse.new(

--- a/src/draw_bot/middleware/canned_response.cr
+++ b/src/draw_bot/middleware/canned_response.cr
@@ -75,6 +75,10 @@ module DrawBot
         if uses > data.size
           raise CannedResponseError.new("Template invokes $#{key} more times than its data pool can provide! #{uses} / #{data.size}")
         end
+
+        if data.any? { |entry| entry.empty? }
+          raise CannedResponseError.new("Data source #{key.inspect} contains empty lines")
+        end
       end
     end
 


### PR DESCRIPTION
Empty lines have a random chance to be selected, and will produce
a confusing Discord message. I opted to use validate_template to
check these, to lint invalid spec configurations as well.

Maybe something more robust can be made later (i.e., a CI check to
even stop these from being comitted), but this is the simplest
solution and probably the most practical.