### PR TITLE
Add suggest command

### DIFF
--- a/src/draw_bot.cr
+++ b/src/draw_bot.cr
@@ -6,7 +6,7 @@ module DrawBot
     # Bot configuration
     class_property config do
       if ENV["DRAWBOT_ENV"]? == "test"
-        Config.new("Bot TOKEN", 0_u64, 0_u64, 0_u64)
+        Config.new("Bot TOKEN", 0_u64, 0_u64, 0_u64, "")
       else
         config = Config.from_yaml(File.read("config.yml"))
       end

--- a/src/draw_bot.cr
+++ b/src/draw_bot.cr
@@ -6,7 +6,7 @@ module DrawBot
     # Bot configuration
     class_property config do
       if ENV["DRAWBOT_ENV"]? == "test"
-        Config.new("Bot TOKEN", 0_u64, 0_u64)
+        Config.new("Bot TOKEN", 0_u64, 0_u64, 0_u64)
       else
         config = Config.from_yaml(File.read("config.yml"))
       end

--- a/src/draw_bot/config.cr
+++ b/src/draw_bot/config.cr
@@ -7,11 +7,13 @@ module DrawBot
     property token : String
     property owner_id : UInt64
     property client_id : UInt64
+    property suggestions_channel : UInt64
 
     def initialize(
       @token : String,
       @owner_id : UInt64,
-      @client_id : UInt64
+      @client_id : UInt64,
+      @suggestions_channel: UInt64,
     )
     end
   end

--- a/src/draw_bot/config.cr
+++ b/src/draw_bot/config.cr
@@ -8,12 +8,14 @@ module DrawBot
     property owner_id : UInt64
     property client_id : UInt64
     property suggestions_channel : UInt64
+    property support_server_invite : String
 
     def initialize(
       @token : String,
       @owner_id : UInt64,
       @client_id : UInt64,
       @suggestions_channel: UInt64,
+      @support_server_invite : String
     )
     end
   end

--- a/src/draw_bot/handlers/suggest.cr
+++ b/src/draw_bot/handlers/suggest.cr
@@ -39,8 +39,7 @@ module DrawBot
       "",
       Discord::Embed.new(
         title: "I went ahead and submitted your suggestion!",
-        # TODO: change discord invite to a config value or something.
-        description: "[Be sure to join my development server to discuss your idea.](https://discord.gg/rYJrhSH)",
+        description: "[Be sure to join my development server to discuss your idea.](#{config.support_server_invite})",
         colour: 0x08FF1F,
       )
     )

--- a/src/draw_bot/handlers/suggest.cr
+++ b/src/draw_bot/handlers/suggest.cr
@@ -1,0 +1,48 @@
+module DrawBot
+  client.on_message_create(
+    SplitParser.new("~suggest", join_after: 1, min_args: 1)
+  ) do |payload, context|
+    message = context[SplitParser::Results].arguments.join(' ')
+
+    channel = cache.resolve_channel(payload.channel_id)
+    guild_name = if guild_id = payload.guild_id
+                   cache.resolve_guild(guild_id).name
+                 else
+                   "DM"
+                 end
+
+    created_in = <<-CREATED
+    Server: **#{guild_name}**
+    Channel: **#{channel.name || payload.channel_id}**
+    User: **#{payload.author.username}##{payload.author.discriminator} (#{payload.author.id})**
+    CREATED
+
+    embed = Discord::Embed.new(
+      title: "New Suggestion",
+      description: message,
+      fields: [
+        Discord::EmbedField.new(
+          name: "__**Created In**__",
+          value: created_in
+        ),
+      ],
+      footer: Discord::EmbedFooter.new(text: "Ref Num: #{payload.id}")
+    )
+
+    client.create_message(
+      config.suggestions_channel,
+      "",
+      embed
+    )
+    client.create_message(
+      payload.channel_id,
+      "",
+      Discord::Embed.new(
+        title: "I went ahead and submitted your suggestion!",
+        # TODO: change discord invite to a config value or something.
+        description: "[Be sure to join my development server to discuss your idea.](https://discord.gg/rYJrhSH)",
+        colour: 0x08FF1F,
+      )
+    )
+  end
+end


### PR DESCRIPTION
This adds the suggest command with a little different formatting.
It also adds a new config value `suggestions_channel`.

My thoughts for this in the future is maybe a reaction menu for accepting/denying suggestions that would perhaps... reply to the original channel (or dms)? Or just mark the status in the drawbot server and be done with it.